### PR TITLE
Feat/hpu support

### DIFF
--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /workspace/mockingbird
-WORKDIR /workspace/mockingbird
+COPY . /workspace
+WORKDIR /workspace
 
 # Copy requirements
 COPY requirements.txt /workspace/requirements.txt
@@ -23,3 +23,12 @@ COPY requirements.txt /workspace/requirements.txt
 # Install Python packages
 RUN pip install --upgrade pip \
     && pip install -r requirements.txt \
+    && pip install webrtcvad-wheels
+
+VOLUME [ "/datasets", "/workspace/synthesizer/saved_models/" ]
+
+ENV DATASET_MIRROR=default FORCE_RETRAIN=false TRAIN_DATASETS=aidatatang_200zh\ magicdata\ aishell3\ data_aishell TRAIN_SKIP_EXISTING=true
+
+EXPOSE 8080
+
+ENTRYPOINT [ "/workspace/docker-entrypoint.sh" ]

--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -1,0 +1,25 @@
+# Use the official Gaudi Docker image with PyTorch
+FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0:latest
+
+# Set environment variables for Habana
+ENV HABANA_VISIBLE_DEVICES=all
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+ENV PT_HPU_LAZY_ACC_PAR_MODE=0
+ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=1
+
+# Set timezone to UTC and install essential packages
+ENV DEBIAN_FRONTEND="noninteractive" TZ=Etc/UTC
+RUN apt-get update && apt-get install -y \
+    tzdata \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /workspace/mockingbird
+WORKDIR /workspace/mockingbird
+
+# Copy requirements
+COPY requirements.txt /workspace/requirements.txt
+
+# Install Python packages
+RUN pip install --upgrade pip \
+    && pip install -r requirements.txt \

--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -31,4 +31,4 @@ ENV DATASET_MIRROR=default FORCE_RETRAIN=false TRAIN_DATASETS=aidatatang_200zh\ 
 
 EXPOSE 8080
 
-ENTRYPOINT [ "/workspace/docker-entrypoint.sh" ]
+CMD ["python", "gen_voice.py", "encoder/saved_models/pretrained.pt", "synthesizer/saved_models/mandarin.pt", "vocoder/saved_models/pretrained/g_hifigan.pt", "data/input.txt", "output.wav", "output.txt"]

--- a/benchmark_hpu.py
+++ b/benchmark_hpu.py
@@ -1,0 +1,175 @@
+import habana_frameworks.torch
+import time
+import logging
+from pathlib import Path
+from models.synthesizer.inference import Synthesizer
+from models.encoder import inference as encoder
+from models.vocoder.hifigan import inference as gan_vocoder
+from pathlib import Path
+import numpy as np
+import soundfile as sf
+import torch
+import sys
+import os
+import re
+import cn2an
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+vocoder = gan_vocoder
+
+def create_input_file(txt_file_name):
+    with open(txt_file_name, "w") as f:
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+        f.write("你好，我是一个AI\n")
+        f.write("我是一个AI，你好\n")
+
+def gen_one_wav(synthesizer, vocoder, in_fpath, embed, texts, file_name, seq, device):
+    embeds = [embed] * len(texts)
+    # If you know what the attention layer alignments are, you can retrieve them here by
+    # passing return_alignments=True
+    specs = synthesizer.synthesize_spectrograms(texts, embeds, style_idx=-1, min_stop_token=4, steps=400)
+    #spec = specs[0]
+    breaks = [spec.shape[1] for spec in specs]
+    spec = np.concatenate(specs, axis=1)
+
+    # If seed is specified, reset torch seed and reload vocoder
+    # Synthesizing the waveform is fairly straightforward. Remember that the longer the
+    # spectrogram, the more time-efficient the vocoder.
+    generated_wav, output_sample_rate = vocoder.infer_waveform(spec)
+    
+    # Add breaks
+    b_ends = np.cumsum(np.array(breaks) * synthesizer.hparams.hop_size)
+    b_starts = np.concatenate(([0], b_ends[:-1]))
+    wavs = [generated_wav[start:end] for start, end, in zip(b_starts, b_ends)]
+    breaks = [np.zeros(int(0.15 * synthesizer.sample_rate))] * len(breaks)
+    generated_wav = np.concatenate([i for w, b in zip(wavs, breaks) for i in (w, b)])
+    
+    ## Post-generation
+    # There's a bug with sounddevice that makes the audio cut one second earlier, so we
+    # pad it.
+
+    # Trim excess silences to compensate for gaps in spectrograms (issue #53)
+    generated_wav = encoder.preprocess_wav(generated_wav)
+    generated_wav = generated_wav / np.abs(generated_wav).max() * 0.97
+        
+    # Save it on the disk
+    model=os.path.basename(in_fpath)
+    filename = "%s_%d_%s.wav" % ("data/output", time.time(), device)
+    sf.write(filename, generated_wav, synthesizer.sample_rate)
+
+    print("\nSaved output as %s\n\n" % filename)
+    
+    
+def generate_wav(encoder, synthesizer, vocoder, in_fpath, input_txt, file_name, device): 
+    start = time.perf_counter()
+    
+    encoder_wav = synthesizer.load_preprocess_wav(in_fpath)
+    embed, partial_embeds, _ = encoder.embed_utterance(encoder_wav, return_partials=True)
+
+    texts = input_txt.split("\n")
+    seq=0
+    each_num=1500
+    
+    punctuation = '！，。、,' # punctuate and split/clean text
+    processed_texts = []
+    cur_num = 0
+    for text in texts:
+      for processed_text in re.sub(r'[{}]+'.format(punctuation), '\n', text).split('\n'):
+        if processed_text:
+            processed_texts.append(processed_text.strip())
+            cur_num += len(processed_text.strip())
+      if cur_num > each_num:
+        seq = seq +1
+        gen_one_wav(synthesizer, vocoder, in_fpath, embed, processed_texts, file_name, seq, device)
+        processed_texts = []
+        cur_num = 0
+    
+    if len(processed_texts)>0:
+      seq = seq +1
+      gen_one_wav(synthesizer, vocoder, in_fpath, embed, processed_texts, file_name, seq, device)
+    
+    end = time.perf_counter()
+    return end - start
+    
+def run(encoder, synthesizer, vocoder, device: str = None):    
+    my_txt = ""
+    
+    txt_file_name = Path("data/input.txt")
+    wav_file_name = Path("data/samples/T0055G0013S0005.wav")
+    
+    if not txt_file_name.exists():
+        print(f"Input file {txt_file_name} does not exist. Creating a sample input file.")
+        create_input_file(txt_file_name)
+    
+    with open(txt_file_name, "r") as f:
+        for line in f.readlines():
+            my_txt += line
+
+    output = cn2an.transform(my_txt, "an2cn")
+    print(output)
+    runtime = generate_wav(
+        encoder,
+        synthesizer,
+        vocoder, 
+        wav_file_name, 
+        output, 
+        txt_file_name, 
+        device,
+    )
+    logger.info(f"Execution time: {runtime:.4f} seconds")
+    return runtime
+
+def run_n_times(n: int, device: str = None):
+    ENC_MODEL_FPATH = Path("data/ckpt/encoder/pretrained.pt")
+    SYN_MODEL_FPATH = Path("data/ckpt/synthesizer/pretrained/mandarin.pt")
+    VOC_MODEL_FPATH = Path("data/ckpt/vocoder/pretrained/g_hifigan.pt")
+    
+    print("Preparing the encoder, the synthesizer and the vocoder...")
+    encoder.load_model(ENC_MODEL_FPATH, device=device)
+    synthesizer = Synthesizer(SYN_MODEL_FPATH, device=device)
+    vocoder.load_model(VOC_MODEL_FPATH, device=device)
+    
+    times = []
+    
+    for i in range(n):
+        runtime = run(encoder, synthesizer, vocoder, device)
+        times.append(runtime)
+    return np.mean(times)
+
+if __name__ == "__main__":
+    logger.debug("Running on HPU")
+    hpu_time = run_n_times(3, "hpu")
+    
+    logger.debug("Running on CPU")
+    cpu_time = run_n_times(3, "cpu")
+    
+    logger.info(f"HPU time: {hpu_time:.4f} seconds")
+    logger.info(f"CPU time: {cpu_time:.4f} seconds")
+

--- a/control/mkgui/app_vc.py
+++ b/control/mkgui/app_vc.py
@@ -15,6 +15,7 @@ from control.mkgui.base.components.types import FileContent
 from models.encoder import inference as speacker_encoder
 from models.synthesizer.inference import Synthesizer
 from models.vocoder.hifigan import inference as gan_vocoder
+from utils.util import get_device
 
 # Constants
 AUDIO_SAMPLES_DIR = f'data{os.sep}samples{os.sep}'
@@ -140,7 +141,7 @@ def convert(input: Input) -> Output:
     min_len = min(ppg.shape[1], len(lf0_uv))
     ppg = ppg[:, :min_len]
     lf0_uv = lf0_uv[:min_len]
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(get_device())
     _, mel_pred, att_ws = convertor.inference(
         ppg,
         logf0_uv=torch.from_numpy(lf0_uv).unsqueeze(0).float().to(device),

--- a/control/toolbox/__init__.py
+++ b/control/toolbox/__init__.py
@@ -7,6 +7,7 @@ from models.vocoder.fregan import inference as fgan_vocoder
 from pathlib import Path
 from time import perf_counter as timer
 from control.toolbox.utterance import Utterance
+from utils.util import get_device
 import numpy as np
 import traceback
 import sys
@@ -369,7 +370,7 @@ class Toolbox:
         if not self.extractor is None:
             ppg = self.extractor.extract_from_wav(src_wav)
         
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = torch.device(get_device())
         ref_wav = self.ui.selected_utterance.wav
         # Import necessary dependency of Voice Conversion
         from utils.f0_utils import compute_f0, f02lf0, compute_mean_std, get_converted_lf0uv   

--- a/gen_voice.py
+++ b/gen_voice.py
@@ -1,3 +1,4 @@
+import habana_frameworks.torch
 from models.synthesizer.inference import Synthesizer
 from models.encoder import inference as encoder
 from models.vocoder.hifigan import inference as gan_vocoder
@@ -108,9 +109,9 @@ if (len(sys.argv)>=3):
     output = cn2an.transform(my_txt, "an2cn")
     print(output)
     generate_wav(
-    Path("encoder/saved_models/pretrained.pt"),
-    Path("synthesizer/saved_models/mandarin.pt"),
-    Path("vocoder/saved_models/pretrained/g_hifigan.pt"), wav_file_name, output, txt_file_name
+    Path("data/ckpt/encoder/pretrained.pt"),
+    Path("data/ckpt/synthesizer/pretrained/mandarin.pt"),
+    Path("data/ckpt/vocoder/pretrained/g_hifigan.pt"), wav_file_name, output, txt_file_name
     )
 
 else:

--- a/gen_voice.py
+++ b/gen_voice.py
@@ -109,9 +109,9 @@ if (len(sys.argv)>=3):
     output = cn2an.transform(my_txt, "an2cn")
     print(output)
     generate_wav(
-    Path("data/ckpt/encoder/pretrained.pt"),
-    Path("data/ckpt/synthesizer/pretrained/mandarin.pt"),
-    Path("data/ckpt/vocoder/pretrained/g_hifigan.pt"), wav_file_name, output, txt_file_name
+    Path("encoder/saved_models/pretrained.pt"),
+    Path("synthesizer/saved_models/mandarin.pt"),
+    Path("vocoder/saved_models/pretrained/g_hifigan.pt"), wav_file_name, output, txt_file_name
     )
 
 else:

--- a/models/encoder/inference.py
+++ b/models/encoder/inference.py
@@ -26,10 +26,8 @@ def load_model(weights_fpath: Path, device=None):
     # TODO: I think the slow loading of the encoder might have something to do with the device it
     #   was saved on. Worth investigating.
     global _model, _device
-    if device is None:
-        _device = torch.device(get_device(device))
-    elif isinstance(device, str):
-        _device = torch.device(device)
+    
+    _device = torch.device(get_device(device))
     _model = SpeakerEncoder(_device, torch.device("cpu"))
     checkpoint = torch.load(weights_fpath, torch.device("cpu"))
     _model.load_state_dict(checkpoint["model_state"])

--- a/models/encoder/inference.py
+++ b/models/encoder/inference.py
@@ -3,6 +3,7 @@ from models.encoder.model import SpeakerEncoder
 from models.encoder.audio import preprocess_wav   # We want to expose this function from here
 from matplotlib import cm
 from models.encoder import audio
+from utils.util import get_device
 from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,7 +27,7 @@ def load_model(weights_fpath: Path, device=None):
     #   was saved on. Worth investigating.
     global _model, _device
     if device is None:
-        _device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        _device = torch.device(get_device(device))
     elif isinstance(device, str):
         _device = torch.device(device)
     _model = SpeakerEncoder(_device, torch.device("cpu"))
@@ -40,7 +41,7 @@ def set_model(model, device=None):
     global _model, _device
     _model = model
     if device is None:
-        _device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        _device = torch.device(get_device(device))
     _device = device
     _model.to(device)
 

--- a/models/encoder/inference.py
+++ b/models/encoder/inference.py
@@ -31,9 +31,9 @@ def load_model(weights_fpath: Path, device=None):
     elif isinstance(device, str):
         _device = torch.device(device)
     _model = SpeakerEncoder(_device, torch.device("cpu"))
-    checkpoint = torch.load(weights_fpath, _device)
+    checkpoint = torch.load(weights_fpath, torch.device("cpu"))
     _model.load_state_dict(checkpoint["model_state"])
-    _model.eval()
+    _model.eval().to(_device)
     print("Loaded encoder \"%s\" trained to step %d" % (weights_fpath.name, checkpoint["step"]))
     return _model
     

--- a/models/ppg2mel/__init__.py
+++ b/models/ppg2mel/__init__.py
@@ -14,8 +14,9 @@ from .utils.abs_model import AbsMelDecoder
 from .rnn_decoder_mol import Decoder
 from .utils.cnn_postnet import Postnet
 from .utils.vc_utils import get_mask_from_lengths
-
+from utils.util import get_device
 from utils.hparams import HpsYaml
+
 
 class MelDecoderMOLv2(AbsMelDecoder):
     """Use an encoder to preprocess ppg."""
@@ -197,7 +198,7 @@ def load_model(model_file, device=None):
     if len(model_config_fpaths) == 0:
         raise "No model yaml config found for convertor"
     if device is None:
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = torch.device(get_device())
 
     model_config = HpsYaml(model_config_fpaths[0])
     ppg2mel_model = MelDecoderMOLv2(

--- a/models/ppg2mel/preprocess.py
+++ b/models/ppg2mel/preprocess.py
@@ -12,7 +12,7 @@ import encoder.inference as Encoder
 from models.encoder.audio import preprocess_wav
 from models.encoder import audio
 from utils.f0_utils import compute_f0
-
+from utils.util import get_device
 from torch.multiprocessing import Pool, cpu_count
 from functools import partial
 
@@ -90,7 +90,7 @@ def preprocess_dataset(datasets_root, dataset, out_dir, n_processes, ppg_encoder
     if n_processes is None:
         n_processes = cpu_count()
     
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(get_device())
     func = partial(preprocess_one, out_dir=out_dir, ppg_model_local=ppg_model_local, encoder_model_local=encoder_model_local, device=device)
     job = Pool(n_processes).imap(func, wav_file_list)
     list(tqdm(job, "Preprocessing", len(wav_file_list), unit="wav"))

--- a/models/ppg_extractor/__init__.py
+++ b/models/ppg_extractor/__init__.py
@@ -6,7 +6,7 @@ import yaml
 from .frontend import DefaultFrontend
 from .utterance_mvn import UtteranceMVN
 from .encoder.conformer_encoder import ConformerEncoder
-
+from utils.util import get_device
 _model = None # type: PPGModel
 _device = None
 
@@ -76,7 +76,7 @@ def load_model(model_file, device=None):
     global _model, _device
     
     if device is None:
-        _device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        _device = torch.device(get_device(device))
     else:
         _device = device
     # search a config file

--- a/models/synthesizer/inference.py
+++ b/models/synthesizer/inference.py
@@ -1,4 +1,3 @@
-import habana_frameworks.torch
 import torch
 from models.synthesizer import audio
 from models.synthesizer.hparams import hparams

--- a/models/synthesizer/inference.py
+++ b/models/synthesizer/inference.py
@@ -1,3 +1,4 @@
+import habana_frameworks.torch
 import torch
 from models.synthesizer import audio
 from models.synthesizer.hparams import hparams
@@ -63,8 +64,8 @@ class Synthesizer:
                                stop_threshold=hparams.tts_stop_threshold,
                                speaker_embedding_size=hparams.speaker_embedding_size).to(self.device)
 
-        self._model.load(self.model_fpath, self.device)
-        self._model.eval()
+        self._model.load(self.model_fpath, torch.device("cpu"))
+        self._model.eval().to(self.device)
 
         if self.verbose:
             print("Loaded synthesizer \"%s\" trained to step %d" % (self.model_fpath.name, self._model.state_dict()["step"]))

--- a/models/synthesizer/inference.py
+++ b/models/synthesizer/inference.py
@@ -11,7 +11,7 @@ import numpy as np
 import librosa
 from utils import logmmse
 from pypinyin import lazy_pinyin, Style
-
+from utils.util import get_device
 class Synthesizer:
     sample_rate = hparams.sample_rate
     hparams = hparams
@@ -27,10 +27,7 @@ class Synthesizer:
         self.verbose = verbose
  
         # Check for GPU
-        if torch.cuda.is_available():
-            self.device = torch.device("cuda")
-        else:
-            self.device = torch.device("cpu")
+        self.device = torch.device(get_device())
         if self.verbose:
             print("Synthesizer using device:", self.device)
         

--- a/models/synthesizer/inference.py
+++ b/models/synthesizer/inference.py
@@ -17,7 +17,7 @@ class Synthesizer:
     sample_rate = hparams.sample_rate
     hparams = hparams
     
-    def __init__(self, model_fpath: Path, verbose=True):
+    def __init__(self, model_fpath: Path, verbose=True, device: str = None):
         """
         The model isn't instantiated and loaded in memory until needed or until load() is called.
         
@@ -26,9 +26,8 @@ class Synthesizer:
         """
         self.model_fpath = model_fpath
         self.verbose = verbose
- 
-        # Check for GPU
-        self.device = torch.device(get_device())
+
+        self.device = torch.device(get_device(device))
         if self.verbose:
             print("Synthesizer using device:", self.device)
         

--- a/models/synthesizer/models/base.py
+++ b/models/synthesizer/models/base.py
@@ -52,7 +52,12 @@ class Base(nn.Module):
             state = checkpoint["model_state"]
         else:
             state = checkpoint["model"]
-        self.load_state_dict(state, strict=False)
+        
+        model_state = self.state_dict()
+        filtered_state_dict = {k: v for k, v in state.items() 
+            if k in model_state and model_state[k].size() == v.size()}
+        state.update(filtered_state_dict)
+        self.load_state_dict(filtered_state_dict, strict=False)
 
         if "optimizer_state" in checkpoint and optimizer is not None:
             optimizer.load_state_dict(checkpoint["optimizer_state"])

--- a/models/synthesizer/preprocess_audio.py
+++ b/models/synthesizer/preprocess_audio.py
@@ -12,7 +12,7 @@ from pypinyin.core import Pinyin
 import torch
 from transformers import Wav2Vec2Processor
 from .models.wav2emo import EmotionExtractorModel
-
+from utils.util import get_device
 class PinyinConverter(NeutralToneWith5Mixin, DefaultConverter):
     pass
 
@@ -20,7 +20,7 @@ pinyin = Pinyin(PinyinConverter()).pinyin
 
 
 # load model from hub 
-device = 'cuda' if torch.cuda.is_available() else "cpu"
+device = get_device()
 model_name = 'audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim'
 processor = Wav2Vec2Processor.from_pretrained(model_name)
 model = EmotionExtractorModel.from_pretrained(model_name).to(device)

--- a/models/synthesizer/synthesize.py
+++ b/models/synthesizer/synthesize.py
@@ -3,6 +3,7 @@ from torch.utils.data import DataLoader
 from models.synthesizer.synthesizer_dataset import SynthesizerDataset, collate_synthesizer
 from models.synthesizer.models.tacotron import Tacotron
 from models.synthesizer.utils.symbols import symbols
+from utils.util import get_device
 import numpy as np
 from pathlib import Path
 from tqdm import tqdm
@@ -16,8 +17,8 @@ def run_synthesis(in_dir, out_dir, model_dir, hparams):
     print(str(hparams))
 
     # Check for GPU
-    if torch.cuda.is_available():
-        device = torch.device("cuda")
+    device = torch.device(get_device())
+    if str(device) in ["cuda", "hpu"]:
         if hparams.synthesis_batch_size % torch.cuda.device_count() != 0:
             raise ValueError("`hparams.synthesis_batch_size` must be evenly divisible by n_gpus!")
     else:

--- a/models/vocoder/fregan/inference.py
+++ b/models/vocoder/fregan/inference.py
@@ -5,7 +5,7 @@ import json
 import torch
 from utils.util import AttrDict
 from models.vocoder.fregan.generator import FreGAN
-
+from utils.util import get_device
 generator = None       # type: FreGAN
 output_sample_rate = None
 _device = None
@@ -38,11 +38,7 @@ def load_model(weights_fpath, config_fpath=None, verbose=True):
     output_sample_rate = h.sampling_rate
     torch.manual_seed(h.seed)
 
-    if torch.cuda.is_available():
-        # _model = _model.cuda()
-        _device = torch.device('cuda')
-    else:
-        _device = torch.device('cpu')
+    _device = torch.device(get_device())
 
     generator = FreGAN(h).to(_device)
     state_dict_g = load_checkpoint(

--- a/models/vocoder/hifigan/inference.py
+++ b/models/vocoder/hifigan/inference.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import habana_frameworks.torch
 import os
 import json
 import torch

--- a/models/vocoder/hifigan/inference.py
+++ b/models/vocoder/hifigan/inference.py
@@ -21,7 +21,7 @@ def load_checkpoint(filepath, device):
     return checkpoint_dict
 
 
-def load_model(weights_fpath, config_fpath=None, verbose=True):
+def load_model(weights_fpath, config_fpath=None, verbose=True, device: str = None):
     global generator, _device, output_sample_rate
 
     if verbose:
@@ -40,8 +40,9 @@ def load_model(weights_fpath, config_fpath=None, verbose=True):
     output_sample_rate = h.sampling_rate
     torch.manual_seed(h.seed)
 
-    _device = torch.device(get_device())
-
+    _device = torch.device(get_device(device))
+    if verbose:
+        print("Vocoder using device:", _device)
     generator = Generator(h).to(_device)
     state_dict_g = load_checkpoint(
         weights_fpath, torch.device("cpu")

--- a/models/vocoder/hifigan/inference.py
+++ b/models/vocoder/hifigan/inference.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import habana_frameworks.torch
 import os
 import json
 import torch
@@ -43,10 +44,10 @@ def load_model(weights_fpath, config_fpath=None, verbose=True):
 
     generator = Generator(h).to(_device)
     state_dict_g = load_checkpoint(
-        weights_fpath, _device
+        weights_fpath, torch.device("cpu")
     )
     generator.load_state_dict(state_dict_g['generator'])
-    generator.eval()
+    generator.eval().to(_device)
     generator.remove_weight_norm()
 
 

--- a/models/vocoder/hifigan/inference.py
+++ b/models/vocoder/hifigan/inference.py
@@ -5,6 +5,7 @@ import json
 import torch
 from utils.util import AttrDict
 from models.vocoder.hifigan.models import Generator
+from utils.util import get_device
 
 generator = None       # type: Generator
 output_sample_rate = None     
@@ -38,11 +39,7 @@ def load_model(weights_fpath, config_fpath=None, verbose=True):
     output_sample_rate = h.sampling_rate
     torch.manual_seed(h.seed)
 
-    if torch.cuda.is_available():
-        # _model = _model.cuda()
-        _device = torch.device('cuda')
-    else:
-        _device = torch.device('cpu')
+    _device = torch.device(get_device())
 
     generator = Generator(h).to(_device)
     state_dict_g = load_checkpoint(

--- a/models/vocoder/wavernn/inference.py
+++ b/models/vocoder/wavernn/inference.py
@@ -1,5 +1,6 @@
 from models.vocoder.wavernn.models.fatchord_version import WaveRNN
 from models.vocoder.wavernn import hparams as hp
+from utils.util import get_device
 import torch
 
 
@@ -25,11 +26,7 @@ def load_model(weights_fpath, verbose=True):
         mode=hp.voc_mode
     )
 
-    if torch.cuda.is_available():
-        _model = _model.cuda()
-        _device = torch.device('cuda')
-    else:
-        _device = torch.device('cpu')
+    _device = torch.device(get_device())
     
     if verbose:
         print("Loading model weights at %s" % weights_fpath)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ visdom
 librosa
 matplotlib>=3.3.0
 numpy==1.19.3; platform_system == "Windows"
-numpy==1.20.3; platform_system != "Windows"
+numpy>=1.21.0; platform_system != "Windows"
 scipy>=1.0.0
 tqdm
 sounddevice

--- a/run.py
+++ b/run.py
@@ -15,6 +15,7 @@ from models.encoder import inference as speacker_encoder
 from models.vocoder.hifigan import inference as vocoder
 from models.ppg2mel import MelDecoderMOLv2
 from utils.f0_utils import compute_f0, f02lf0, compute_mean_std, get_converted_lf0uv
+from utils.util import get_device
 
 
 def _build_ppg2mel_model(model_config, model_file, device):
@@ -29,7 +30,7 @@ def _build_ppg2mel_model(model_config, model_file, device):
 
 @torch.no_grad()
 def convert(args):
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(get_device())
     output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
 

--- a/utils/util.py
+++ b/utils/util.py
@@ -157,7 +157,7 @@ def get_device(preferred_device: str = None) -> str:
         preferred_device (str): The preferred device to use. Can be "hpu", "cuda", or "cpu".
         
     Returns:
-        torch.device: Device object - either torch.device("hpu"), torch.device("cuda"), or torch.device("cpu")
+        str: The device to use for PyTorch operations.
     """
     if preferred_device == "hpu" or preferred_device is None:
       if importlib.util.find_spec("habana_frameworks"):

--- a/utils/util.py
+++ b/utils/util.py
@@ -161,7 +161,7 @@ def get_device(preferred_device: str = None) -> str:
     """
     if preferred_device == "hpu" or preferred_device is None:
       if importlib.util.find_spec("habana_frameworks"):
-        from habana_frameworks.torch.library_loader import load_habana_module
+        from habana_frameworks.torch.utils.library_loader import load_habana_module
         load_habana_module()
         if torch.hpu.is_available():
           return "hpu"


### PR DESCRIPTION
This PR introduces support for Habana Gaudi (HPU) acceleration and improves device handling across the project. Key changes include:  

### New HPU-Compatible Dockerfile
  - Added `Dockerfile.hpu` to support Habana Gaudi with PyTorch.  
  - Uses `vault.habana.ai/gaudi-docker` as the base image.  
  - Installs necessary dependencies and sets environment variables for HPU.  

### Benchmarking on HPU
  - Introduced `benchmark_hpu.py` to compare execution times between CPU and HPU.  
  - Uses `habana_frameworks.torch` for HPU acceleration.  

### Refactored Device Selection
  - Unified device selection via `get_device()` in `utils/util.py`.  
  - Replaced multiple scattered `torch.device("cuda" if torch.cuda.is_available() else "cpu")` checks.  
  - Now prioritizes HPU if available, then CUDA, falling back to CPU.  

### Model Loading Adjustments
  - Ensured models are first loaded on CPU before transferring to the appropriate device to prevent issues with incompatible state dictionaries.  
  - Updated synthesizer, vocoder, encoder, and other model scripts accordingly.  

### Dependency Updates
  - Updated `requirements.txt` to allow NumPy versions `>=1.21.0` for better compatibility.  

## Why
- Adds Habana Gaudi acceleration support for improved training and inference performance.  
- Standardizes device management for easier maintainability.  
- Enhances model compatibility across different hardware configurations.  

## Testing
- Verified model loading and inference on HPU, CUDA, and CPU.  
- Benchmark (3 runs averaged) shows a **16.25× speedup** on HPU vs CPU:  
  - **HPU:** ~23.04 seconds  
  - **CPU:** ~374.27 seconds 